### PR TITLE
fix: updated the package installation name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Asegúrate de que tu entorno de ejecución cumple los siguientes requisitos:
 
 Puedes instalar la librería utilizando el gestor de dependencias [Composer](https://getcomposer.org/):
 ```sh
-composer require verifactu-php
+composer require josemmo/verifactu-php
 ```
 
 ## Ejemplo de uso


### PR DESCRIPTION
Just fixed a little typo on the installation, when pasting the previous install command it gave multiple options, this way we'll ensure the correct option is installed