### PR TITLE
Add mandatory TipoRectificativa field for 2024 VERI*FACTU compliance

### DIFF
--- a/src/Models/Records/RectificationType.php
+++ b/src/Models/Records/RectificationType.php
@@ -1,0 +1,27 @@
+<?php
+namespace josemmo\Verifactu\Models\Records;
+
+/**
+ * Enumeración de tipos de rectificación
+ *
+ * Según la normativa VERI*FACTU actualizada de 2024,
+ * las facturas rectificativas deben especificar el tipo de rectificación
+ */
+enum RectificationType: string {
+    /**
+     * Por sustitución
+     *
+     * Se emite una factura rectificativa que sustituye completamente
+     * a la factura original. La factura original queda anulada.
+     */
+    case PorSustitucion = 'S';
+
+    /**
+     * Por diferencias
+     *
+     * Se emite una factura rectificativa que complementa la factura original,
+     * corrigiendo únicamente las diferencias en importes o datos específicos.
+     * La factura original sigue siendo válida.
+     */
+    case PorDiferencias = 'I';
+}

--- a/src/Models/Records/RegistrationRecord.php
+++ b/src/Models/Records/RegistrationRecord.php
@@ -48,6 +48,16 @@ class RegistrationRecord extends Record {
     public array $recipients = [];
 
     /**
+     * Tipo de rectificación
+     *
+     * Obligatorio para facturas rectificativas (R1, R2, R3, R4, R5)
+     * Según normativa VERI*FACTU actualizada de 2024
+     *
+     * @field TipoRectificativa
+     */
+    public ?RectificationType $rectificationType = null;
+
+    /**
      * Desglose de la factura
      *
      * @var BreakdownDetails[]
@@ -148,6 +158,31 @@ class RegistrationRecord extends Record {
         } elseif (!$hasRecipients) {
             $context->buildViolation('This type of invoice requires at least one recipient')
                 ->atPath('recipients')
+                ->addViolation();
+        }
+    }
+
+    #[Assert\Callback]
+    final public function validateRectificationType(ExecutionContextInterface $context): void {
+        if (!isset($this->invoiceType)) {
+            return;
+        }
+
+        $isRectificativeInvoice = in_array($this->invoiceType, [
+            InvoiceType::R1,
+            InvoiceType::R2,
+            InvoiceType::R3,
+            InvoiceType::R4,
+            InvoiceType::R5
+        ], true);
+
+        if ($isRectificativeInvoice && $this->rectificationType === null) {
+            $context->buildViolation('Rectificative invoices require a rectification type (TipoRectificativa)')
+                ->atPath('rectificationType')
+                ->addViolation();
+        } elseif (!$isRectificativeInvoice && $this->rectificationType !== null) {
+            $context->buildViolation('Only rectificative invoices can have a rectification type')
+                ->atPath('rectificationType')
                 ->addViolation();
         }
     }

--- a/src/Services/AeatClient.php
+++ b/src/Services/AeatClient.php
@@ -184,6 +184,12 @@ class AeatClient {
 
         $recordElement->add('sum1:NombreRazonEmisor', $record->issuerName);
         $recordElement->add('sum1:TipoFactura', $record->invoiceType->value);
+
+        // TipoRectificativa es obligatorio para facturas rectificativas (nueva normativa 2024)
+        if ($record->rectificationType !== null) {
+            $recordElement->add('sum1:TipoRectificativa', $record->rectificationType->value);
+        }
+
         $recordElement->add('sum1:DescripcionOperacion', $record->description);
 
         if (count($record->recipients) > 0) {


### PR DESCRIPTION
Implements the new TipoRectificativa requirement for rectificative invoices as mandated by AEAT's updated regulations. Adds RectificationType enum with values 'S' (substitution) and 'I' (differences), automatic validation, and XML serialization support.