### PR TITLE
Do not send some breakdown fields when operation type is exempt

### DIFF
--- a/src/Services/AeatClient.php
+++ b/src/Services/AeatClient.php
@@ -235,13 +235,16 @@ class AeatClient {
 
         $desgloseElement = $recordElement->add('sum1:Desglose');
         foreach ($record->breakdown as $breakdownDetails) {
+            $isExempt = (OperationType::N1 === $breakdownDetails->operationType || OperationType::N2 === $breakdownDetails->operationType);
             $detalleDesgloseElement = $desgloseElement->add('sum1:DetalleDesglose');
             $detalleDesgloseElement->add('sum1:Impuesto', $breakdownDetails->taxType->value);
             $detalleDesgloseElement->add('sum1:ClaveRegimen', $breakdownDetails->regimeType->value);
             $detalleDesgloseElement->add('sum1:CalificacionOperacion', $breakdownDetails->operationType->value);
-            $detalleDesgloseElement->add('sum1:BaseImponibleOimporteNoSujeto', $breakdownDetails->baseAmount);
-            if (OperationType::N1 !== $breakdownDetails->operationType && OperationType::N2 !== $breakdownDetails->operationType) {
+            if (!isExempt) {
                 $detalleDesgloseElement->add('sum1:TipoImpositivo', $breakdownDetails->taxRate);
+            }
+            $detalleDesgloseElement->add('sum1:BaseImponibleOimporteNoSujeto', $breakdownDetails->baseAmount);
+            if (!isExempt) {
                 $detalleDesgloseElement->add('sum1:CuotaRepercutida', $breakdownDetails->taxAmount);
             }
         }


### PR DESCRIPTION
Related error:

"1237 = El valor del campo CalificacionOperacion está informado como Operación No sujeta (N1 o N2) y el impuesto es IVA. No se puede informar de los campos TipoImpositivo, CuotaRepercutida, TipoRecargoEquivalencia y CuotaRecargoEquivalencia."

https://prewww2.aeat.es/static_files/common/internet/dep/aplicaciones/es/aeat/tikeV1.0/cont/ws/errores.properties