### PR TITLE
feat: add RDE tax surplus to validation

### DIFF
--- a/src/Models/Records/RegistrationRecord.php
+++ b/src/Models/Records/RegistrationRecord.php
@@ -145,7 +145,14 @@ class RegistrationRecord extends Record {
             if (!isset($details->taxAmount) || !isset($details->baseAmount)) {
                 return;
             }
+            // Sum IVA tax amount
             $expectedTotalTaxAmount += $details->taxAmount;
+            
+            // Also add surcharge amount if present (Recargo de Equivalencia)
+            if (isset($details->surchargeAmount)) {
+                $expectedTotalTaxAmount += $details->surchargeAmount;
+            }
+            
             $totalBaseAmount += $details->baseAmount;
         }
 


### PR DESCRIPTION
Currently validation fails when we send a record with RDE (Recargo de Equivalencia)
The tax total should allow us to send something like:


```php
            $breakdown = [];
            $breakdownIndex = 0;
            
            // 21% IVA + RDE (only add if tax was charged)
            $taxAmount21 = $basket->getTaxStat(21, 'tax', false);
            if ($taxAmount21 > 0) {
                $baseAmount = $basket->getTaxStat(21, 'base', false);
                
                $breakdown[$breakdownIndex] = new BreakdownDetails();
                $breakdown[$breakdownIndex]->taxType = TaxType::IVA;
                $breakdown[$breakdownIndex]->regimeType = RegimeType::C01;
                $breakdown[$breakdownIndex]->operationType = OperationType::Subject;
                $breakdown[$breakdownIndex]->taxRate = '21.00';
                $breakdown[$breakdownIndex]->baseAmount = number_format(round($baseAmount, 2, PHP_ROUND_HALF_UP), 2, '.', '');
                $breakdown[$breakdownIndex]->taxAmount = number_format(round($taxAmount21, 2, PHP_ROUND_HALF_UP), 2, '.', '');
                
                // Add RDE if applicable
                $surchargeAmount = $basket->getSurchargeStat(5.2, 'tax', false);
                if ($surchargeAmount > 0) {
                    $breakdown[$breakdownIndex]->surchargeRate = '5.20';
                    $breakdown[$breakdownIndex]->surchargeAmount = number_format(round($surchargeAmount, 2, PHP_ROUND_HALF_UP), 2, '.', '');
                }
                
                $breakdownIndex++;
            }
            ```