### PR TITLE
Añadir soporte para fecha de operación

### DIFF
--- a/src/Models/Records/RegistrationRecord.php
+++ b/src/Models/Records/RegistrationRecord.php
@@ -38,15 +38,6 @@ class RegistrationRecord extends Record {
     public InvoiceType $invoiceType;
 
     /**
-     * Descripción del objeto de la factura
-     *
-     * @field DescripcionOperacion
-     */
-    #[Assert\NotBlank]
-    #[Assert\Length(max: 500)]
-    public string $description;
-
-    /**
      * Fecha en la que se realiza la operación
      *
      * NOTE: Time part will be ignored.
@@ -54,6 +45,15 @@ class RegistrationRecord extends Record {
      * @field FechaOperacion
      */
     public ?DateTimeImmutable $operationDate = null;
+
+    /**
+     * Descripción del objeto de la factura
+     *
+     * @field DescripcionOperacion
+     */
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 500)]
+    public string $description;
 
     /**
      * Destinatarios de la factura
@@ -330,11 +330,11 @@ class RegistrationRecord extends Record {
             $importeRectificacionElement->add('sum1:CuotaRectificada', $this->correctedTaxAmount);
         }
 
-        $recordElement->add('sum1:DescripcionOperacion', $this->description);
-
         if ($this->operationDate !== null) {
             $recordElement->add('sum1:FechaOperacion', $this->operationDate->format('d-m-Y'));
         }
+
+        $recordElement->add('sum1:DescripcionOperacion', $this->description);
 
         if (count($this->recipients) > 0) {
             $destinatariosElement = $recordElement->add('sum1:Destinatarios');

--- a/tests/Models/Records/RegistrationRecordTest.php
+++ b/tests/Models/Records/RegistrationRecordTest.php
@@ -310,8 +310,8 @@ final class RegistrationRecordTest extends TestCase {
         $record->invoiceId->issueDate = new DateTimeImmutable('2025-06-02');
         $record->issuerName = 'Perico de los Palotes, S.A.';
         $record->invoiceType = InvoiceType::Simplificada;
-        $record->description = 'Factura simplificada de prueba';
         $record->operationDate = new DateTimeImmutable('2025-05-15');
+        $record->description = 'Factura simplificada de prueba';
         $record->breakdown[0] = new BreakdownDetails();
         $record->breakdown[0]->taxType = TaxType::IVA;
         $record->breakdown[0]->regimeType = RegimeType::C01;
@@ -359,8 +359,8 @@ final class RegistrationRecordTest extends TestCase {
                 <sum1:NombreRazonEmisor>Perico de los Palotes, S.A.</sum1:NombreRazonEmisor>
                 <sum1:Subsanacion>N</sum1:Subsanacion>
                 <sum1:TipoFactura>F2</sum1:TipoFactura>
-                <sum1:DescripcionOperacion>Factura simplificada de prueba</sum1:DescripcionOperacion>
                 <sum1:FechaOperacion>15-05-2025</sum1:FechaOperacion>
+                <sum1:DescripcionOperacion>Factura simplificada de prueba</sum1:DescripcionOperacion>
                 <sum1:Desglose>
                     <sum1:DetalleDesglose>
                         <sum1:Impuesto>01</sum1:Impuesto>


### PR DESCRIPTION

Esta PR añade soporte para la fecha de operación en las facturas, mapeándola al campo `FechaOperacion` en el XML de Veri*Factu cuando está informada.

La AEAT distingue explícitamente entre:

* **Fecha de expedición de la factura**: fecha en la que se emite la factura.
* **Fecha de operación**: fecha en la que se realiza realmente la operación, que debe informarse cuando sea distinta de la fecha de expedición.

Referencias de la Agencia Tributaria/BOE:

* [FAQs SII – apartado “2.12. ¿Cuándo debe cumplimentarse el campo fecha de operación?” (página 28)](https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/FaqGral/FAQs_10_02_2025.pdf)
* [BOE-A-2024-22138 – Anexo RRSIF. Definición del campo `FechaOperacion` (página 19)](https://www.boe.es/boe/dias/2024/10/28/pdfs/BOE-A-2024-22138.pdf)

Con este cambio, la librería permite cumplir la obligación de informar `FechaOperacion` cuando sea diferente de la fecha de expedición, alineándose con los requisitos de la AEAT.