### PR TITLE
Lanzar excepción personalizada si la respuesta no es XML

### DIFF
--- a/src/Exceptions/AeatResponseException.php
+++ b/src/Exceptions/AeatResponseException.php
@@ -1,13 +1,12 @@
 <?php
 namespace josemmo\Verifactu\Exceptions;
 
-use RuntimeException;
 use Throwable;
 
 /**
  * Exception thrown by the AEAT client
  */
-class AeatResponseException extends RuntimeException {
+class AeatResponseException extends AeatException {
     public function __construct(
         public readonly string $response,
         string $message,


### PR DESCRIPTION
Hola!

Estaba haciendo pruebas, y he probado un certificado creado y firmado por mí, pues para empezar con algo jejejejeje
En vez de devolver un XML me está devolviendo un HTML y eso hace fallar el parseado de UXML.
<img width="781" height="518" alt="image" src="https://github.com/user-attachments/assets/b48d58e9-6177-4a4a-ae28-35cb8e8a40ab" />

Al final he decido que en caso de fallo al parsear el XML, el usuario decida que hacer con la respuesta.

En este caso tampoco se que es lo mejor, la AEAT devuelve un html y los valores de los assets y enalces no está informado el dominio... `src="/static_files/...` o `... html="/Sede/Inicio.html`
Además, en caso de querer mostrar la página para que el usuario pueda ver lo que ha fallado, se han de cambiar los assets para que apunten a `https://www.agenciatributaria.gob.es/Sede/inicio.html`.

También he visto que el header `Content-Type: text/html` y no haría falta el try catch.
Si realizo alguna prueba más con un certificado válido y veo que el content-type no es el mismo intentaré cambiar el funcionamiento de esta PR.